### PR TITLE
fix: drivetrain inversions

### DIFF
--- a/.pathplanner/settings.json
+++ b/.pathplanner/settings.json
@@ -1,6 +1,6 @@
 {
-  "robotWidth": 0.762,
-  "robotLength": 0.762,
+  "robotWidth": 0.7112,
+  "robotLength": 0.7112,
   "holonomicMode": true,
   "pathFolders": [
     "CenterSpeaker3PiecePath",

--- a/src/main/deploy/pathplanner/paths/Straight Path.path
+++ b/src/main/deploy/pathplanner/paths/Straight Path.path
@@ -16,11 +16,11 @@
     },
     {
       "anchor": {
-        "x": 2.0,
+        "x": 5.0,
         "y": 0.0
       },
       "prevControl": {
-        "x": 0.47999999999999954,
+        "x": 3.4799999999999995,
         "y": 0.0
       },
       "nextControl": null,
@@ -32,18 +32,18 @@
   "constraintZones": [],
   "eventMarkers": [],
   "globalConstraints": {
-    "maxVelocity": 1.0,
-    "maxAcceleration": 3.0,
+    "maxVelocity": 1.5,
+    "maxAcceleration": 2.0,
     "maxAngularVelocity": 540.0,
     "maxAngularAcceleration": 720.0
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": 0,
+    "rotation": 0.0,
     "rotateFast": false
   },
   "reversed": false,
   "folder": null,
   "previewStartingState": null,
-  "useDefaultConstraints": true
+  "useDefaultConstraints": false
 }

--- a/src/main/java/frc/robot/auton/AutonMaster.java
+++ b/src/main/java/frc/robot/auton/AutonMaster.java
@@ -25,11 +25,13 @@ public class AutonMaster {
     private static Field2d mGameField;
     private static SendableChooser<Command> autonChooser = new SendableChooser<>();
 
+    private final Drivetrain drivetrain;
+
     public AutonMaster() {
-        final var drivetrain = Drivetrain.getInstance();
+        drivetrain = Drivetrain.getInstance();
         /* Define Named Commands Here */
 
-        //Zero Heading -> use at the beginning and end of every auton
+//        Zero Heading -> use at the beginning and end of every auton
         NamedCommands.registerCommand("ZeroHeading", new InstantCommand(drivetrain::zeroHeading));
 
         NamedCommands.registerCommand("ResetFieldOrientation", new InstantCommand(() -> {
@@ -41,7 +43,7 @@ public class AutonMaster {
         //Wait Command -> Common Command for Robot to Wait
         NamedCommands.registerCommand("WaitCommand", new WaitCommand(5));
 
-        //Turn in place command -> enter custom angle 
+        //Turn in place command -> enter custom angle
         //This turns 45 deg.
         NamedCommands.registerCommand("TurnInPlace", new TurnInPlaceCommand(45, drivetrain));
 
@@ -100,5 +102,4 @@ public class AutonMaster {
             mGameField.getObject("path").setPoses(poses);
         });
     }
-
 }

--- a/src/main/java/frc/robot/driver/Driver.java
+++ b/src/main/java/frc/robot/driver/Driver.java
@@ -63,13 +63,13 @@ public class Driver extends Gamepad {
     public void setupTestButtons() {}
 
     public Translation2d getDriveTranslation() {
-        final var xComponent = translationStickCurve.calculate(controller.getLeftX());
-        final var yComponent = translationStickCurve.calculate(controller.getLeftY());
+        final var xComponent = translationStickCurve.calculate(-controller.getLeftX());
+        final var yComponent = translationStickCurve.calculate(-controller.getLeftY());
         // Components are reversed because field coordinates are opposite of joystick coordinates
         return new Translation2d(yComponent, xComponent);
     }
 
     public double getDriveRotation() {
-        return -rotationStickCurve.calculate(controller.getRightX());
+        return rotationStickCurve.calculate(-controller.getRightX());
     }
 }

--- a/src/main/java/frc/robot/drivetrain/DrivetrainConfig.java
+++ b/src/main/java/frc/robot/drivetrain/DrivetrainConfig.java
@@ -75,10 +75,9 @@ public class DrivetrainConfig {
 
         /* Drive Motor PID Values */
         //TODO: TUNE THIS BASED ON TESTING
-        public static final double driveKP = 0.08;; 
+        public static final double driveKP = 0.1;;
         public static final double driveKI = 0.0;
         public static final double driveKD = 0.1;
-        public static final double driveKF = 0.001;
 
         /* Drive Motor Characterization Values From SYSID */
         //TODO: This must be tuned to specific robot using SYSID, But Knight Vision Constants work good :)
@@ -87,8 +86,10 @@ public class DrivetrainConfig {
         // public static final double driveKA = 0.06921;
 
         public static final double driveKS = 0.48665; 
-        public static final double driveKV = 2.4132;
-        public static final double driveKA = 0.06921;
+//        public static final double driveKV = 2.4132;
+        public static final double driveKV = 2.2;
+//        public static final double driveKA = 0.06921;
+        public static final double driveKA = 0.37;
 
         /* Swerve Profiling Values */
         /** Meters per Second */
@@ -108,46 +109,46 @@ public class DrivetrainConfig {
         //TODO: TUNE THESE TO THE IDs FOR EACH MOTOR AND CANCODER and FIGURE OUT THE OFFSET
         /* Module Specific Constants */
 
-        // Back Right
-        public static final class Mod0 {
-            public static final int driveMotorID = 12;
-            public static final int angleMotorID = 10;
-            public static final int canCoderID = 11;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(-4.131 + 180);
-            public static final SwerveModuleConfig config =
-                new SwerveModuleConfig(driveMotorID, angleMotorID, canCoderID, angleOffset);
-        }
 
-        // Back Left
-        public static final class Mod1 {
-            public static final int driveMotorID = 3;
-            public static final int angleMotorID = 1;
-            public static final int canCoderID = 2;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(101.426 - 180);
+        // Front Left
+        public static final class Mod0 {
+            public static final int driveMotorID = 6;
+            public static final int angleMotorID = 4;
+            public static final int canCoderID = 5;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(129.023 - 180);
             public static final SwerveModuleConfig config =
                 new SwerveModuleConfig(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }
 
         // Front Right
-        public static final class Mod2 {
+        public static final class Mod1 {
             public static final int driveMotorID = 9;
             public static final int angleMotorID = 7;
             public static final int canCoderID = 8;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(206.806 - 180);
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(206.806);
             public static final SwerveModuleConfig config =
                 new SwerveModuleConfig(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }
 
-        // Front Left
+        // Back Left
+        public static final class Mod2 {
+            public static final int driveMotorID = 3;
+            public static final int angleMotorID = 1;
+            public static final int canCoderID = 2;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(101.426);
+            public static final SwerveModuleConfig config =
+                new SwerveModuleConfig(driveMotorID, angleMotorID, canCoderID, angleOffset);
+        }
+
+        // Back Right
         public static final class Mod3 {
-            public static final int driveMotorID = 6;
-            public static final int angleMotorID = 4;
-            public static final int canCoderID = 5;
-            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(129.023);
+            public static final int driveMotorID = 12;
+            public static final int angleMotorID = 10;
+            public static final int canCoderID = 11;
+            public static final Rotation2d angleOffset = Rotation2d.fromDegrees(-4.131);
             public static final SwerveModuleConfig config =
                 new SwerveModuleConfig(driveMotorID, angleMotorID, canCoderID, angleOffset);
         }
-
     }
 
     public class AutonConstants {


### PR DESCRIPTION
Fixes some of the last remaining drivetrain inversions, ensuring that the swerve drive adheres to WPILib's coordinate system. This should fix some of the issues we were having in auton vs teleop.